### PR TITLE
Update project order on commit

### DIFF
--- a/app/controllers/github_callback_controller.rb
+++ b/app/controllers/github_callback_controller.rb
@@ -1,0 +1,31 @@
+class GithubCallbackController < ApplicationController
+  # Disable CSRF verification for the endpoint GitHub uses
+  skip_before_action :verify_authenticity_token, only: [:receive]
+
+  def receive
+    # Ignore all but `push` events
+    if request.headers["X-GitHub-Event"] != "push"
+      # GitHub Docs advise returning 200 if the webhook was delivered, even if you don't want it
+      render body: nil
+      return
+    end
+
+    # Verify message
+    hash = OpenSSL::HMAC.hexdigest("SHA256", ENV['GITHUB_WEBHOOK_SECRET'], request.raw_post)
+    if request.headers["X-Hub-Signature-256"] != "sha256=#{hash}" # Signatures are in the format `sha256=HASH`
+      render body: nil, status: :unauthorized
+      return
+    end
+
+    # Find project
+    repository_url = params[:repository][:url]
+    project = Project.where("? = ANY(scm_urls)", repository_url)
+
+    if project != nil
+      # Update `display_order` with latest commit's timestamp
+      project.update(display_order: params[:repository][:pushed_at].to_i * 1000)
+    end
+
+    render body: nil
+  end
+end

--- a/app/jobs/github_project_import_job.rb
+++ b/app/jobs/github_project_import_job.rb
@@ -103,7 +103,7 @@ private
       repo,
       "web",
       {
-        url: "https://devgarden.macalester.edu/reorder-project-on-commit",
+        url: github_webhook_url,
         content_type: "json",
         secret: ENV['GITHUB_WEBHOOK_SECRET']
       }

--- a/app/jobs/github_project_import_job.rb
+++ b/app/jobs/github_project_import_job.rb
@@ -18,6 +18,7 @@ class GithubProjectImportJob < ApplicationJob
       import_info(repo)
       import_contributors(repo)
       import_languages(repo)
+      add_webhook(repo)
     end
 
     project.save!
@@ -95,6 +96,18 @@ private
         project.tags << tag
       end
     end
+  end
+
+  def add_webhook(repo)
+    github.create_hook(
+      repo,
+      "web",
+      {
+        url: "https://devgarden.macalester.edu/reorder-project-on-commit",
+        content_type: "json",
+        secret: ENV['GITHUB_WEBHOOK_SECRET']
+      }
+    )
   end
 
   def language_tags

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,6 +1,8 @@
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
+  config.hosts << /.*\.ngrok\.io/
+
   Rails.application.routes.default_url_options.merge!(
     host: 'localhost:8080')
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,9 @@ Rails.application.routes.draw do
 
   get "/invitation/:code" => "invitations#accept", as: :accept_invitation
 
+  # Explains what the webhook that was mysteriously added does
+  post "/reorder-project-on-commit" => "github_callback#receive"
+
   resources :projects
   resources :people
   resources :roles

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,7 @@ Rails.application.routes.draw do
   get "/invitation/:code" => "invitations#accept", as: :accept_invitation
 
   # Explains what the webhook that was mysteriously added does
-  post "/reorder-project-on-commit" => "github_callback#receive"
+  post "/github/webhook" => "github_webhook#receive"
 
   resources :projects
   resources :people


### PR DESCRIPTION
This isn't ready for production, but it does work.

1. Creates a webhook when importing a repository
2. Commits trigger `push` events sent to `/reorder-project-on-commit`
3. Verifies payload signature
4. Updates projects' `display_order` to the timestamp of the last commit

Here are a few things I was thinking about when making it:
- Existing projects don't have webhooks, but I don't think any of them are still active (except the Dev Garden)
- Can multiple projects have the same GitHub repository?
- Project owners can delete the webhook and there's no button to add it back in the admin panel
- Is there a cleaner way to stop execution and return an HTTP error code?
- How would I write a test for this?
- It breaks if the GitHub repository is renamed, but there's no way to fix this without an additional column
- Should the controller have better error handling or more logging?